### PR TITLE
[bugfix] デバッグ用OLEDなしの状態で設定モードから表示モードに遷移してもVFD表示が戻らないのを修正。

### DIFF
--- a/src/mode_ctrl.cpp
+++ b/src/mode_ctrl.cpp
@@ -244,17 +244,15 @@ void modeCtrl::modeSetVfdCnt(uint8_t setKey,uint8_t swKey)
   if((setKey == kEY_SET_L) && !aboteb){        // SETKey SW1 Long ON
     if(ssd1306Valid){
       displayMode.ctrlMode = ctrlMode_Oled;     // M5OLEDなし　OLEDあり 操作モード：VFD設定 -> OLED設定
-      displayMode.dispModeVfdCount = 0;
-      displayMode.dispModeVfd = dispModeVfdTbl[displayMode.dispModeVfdCount];  // VFD表示モード初期化
     }
     else if(m5oledValid){
       displayMode.ctrlMode = ctrlMode_M5oled;   // M5OLEDあり　操作モード：VFD設定 -> M5OLED設定
-      displayMode.dispModeVfdCount = 0;
-      displayMode.dispModeVfd = dispModeVfdTbl[displayMode.dispModeVfdCount];  // VFD表示モード初期化
     }
     else{
       displayMode.ctrlMode = ctrlMode_VfdDisp;  // M5OLEDなし　OLEDなし　操作モード：VFD設定 -> VFD表示
     }
+      displayMode.dispModeVfdCount = 0;
+      displayMode.dispModeVfd = dispModeVfdTbl[displayMode.dispModeVfdCount];  // VFD表示モード初期化
   }
   else if((setKey == kEY_SET_L) && aboteb){     // SETKey SW1 Long ON 設定中断要求
 //    Serial.println("SETKey SW1 Long ON 設定中断要求");

--- a/test/test_mode_ctrl.cpp
+++ b/test/test_mode_ctrl.cpp
@@ -112,17 +112,21 @@ TEST(ModeCtrl, ctrlModechg_Full){
  * M5OLED　なし
  */
 TEST(ModeCtrl, ctrlModechg_OLED){
+  dispMode dispModeData;        // 動作モード
   modeCtrl mode(true,false);    // 操作モード：VFD表示
   EXPECT_EQ(mode.getCtrlMode(), ctrlMode_VfdDisp);
 
-  mode.modeSet(kEY_SET_L,0);      // 操作モード：VFD表示 -> VFD設定
+  dispModeData = mode.modeSet(kEY_SET_L,0);      // 操作モード：VFD表示 -> VFD設定
   EXPECT_EQ(mode.getCtrlMode(), ctrlMode_VfdCtrl);
+  EXPECT_EQ(dispModeData.dispModeVfd, VFD_DISP_CLOCK_ADJ);  // VFD表示モード：時計調整
 
-  mode.modeSet(kEY_SET_L,0);      // 操作モード：VFD設定 -> OLED設定
+  dispModeData = mode.modeSet(kEY_SET_L,0);      // 操作モード：VFD設定 -> OLED設定
   EXPECT_EQ(mode.getCtrlMode(), ctrlMode_Oled);
+  EXPECT_EQ(dispModeData.dispModeVfd, VFD_DISP_DEFAULT);    // VFD表示モード：標準表示
 
-  mode.modeSet(kEY_SET_L,0);      // 操作モード：OLED設定 -> VFD表示
+  dispModeData = mode.modeSet(kEY_SET_L,0);      // 操作モード：OLED設定 -> VFD表示
   EXPECT_EQ(mode.getCtrlMode(), ctrlMode_VfdDisp);
+  EXPECT_EQ(dispModeData.dispModeVfd, VFD_DISP_DEFAULT);    // VFD表示モード：標準表示
 
 //  EXPECT_FALSE(false);
 }
@@ -134,17 +138,21 @@ TEST(ModeCtrl, ctrlModechg_OLED){
  * M5OLED　あり
  */
 TEST(ModeCtrl, ctrlModechg_M5OLED){
+  dispMode dispModeData;        // 動作モード
   modeCtrl mode(false,true);    // 操作モード：VFD表示
   EXPECT_EQ(mode.getCtrlMode(), ctrlMode_VfdDisp);
 
-  mode.modeSet(kEY_SET_L,0);      // 操作モード：VFD表示 -> VFD設定
+  dispModeData = mode.modeSet(kEY_SET_L,0);      // 操作モード：VFD表示 -> VFD設定
   EXPECT_EQ(mode.getCtrlMode(), ctrlMode_VfdCtrl);
+  EXPECT_EQ(dispModeData.dispModeVfd, VFD_DISP_CLOCK_ADJ);  // VFD表示モード：時計調整
 
-  mode.modeSet(kEY_SET_L,0);      // 操作モード：VFD設定 -> M5OLED設定
+  dispModeData = mode.modeSet(kEY_SET_L,0);      // 操作モード：VFD設定 -> M5OLED設定
   EXPECT_EQ(mode.getCtrlMode(), ctrlMode_M5oled);
+  EXPECT_EQ(dispModeData.dispModeVfd, VFD_DISP_DEFAULT);    // VFD表示モード：標準表示
 
-  mode.modeSet(kEY_SET_L,0);      // 操作モード：M5OLED設定 -> VFD表示
+  dispModeData = mode.modeSet(kEY_SET_L,0);      // 操作モード：M5OLED設定 -> VFD表示
   EXPECT_EQ(mode.getCtrlMode(), ctrlMode_VfdDisp);
+  EXPECT_EQ(dispModeData.dispModeVfd, VFD_DISP_DEFAULT);    // VFD表示モード：標準表示
 
 }
 
@@ -155,14 +163,17 @@ TEST(ModeCtrl, ctrlModechg_M5OLED){
  * M5OLED　無し
  */
 TEST(ModeCtrl, ctrlModechg_NoOLED){
+  dispMode dispModeData;        // 動作モード
   modeCtrl mode(false,false);   // 操作モード：VFD表示
   EXPECT_EQ(mode.getCtrlMode(), ctrlMode_VfdDisp);
 
-  mode.modeSet(kEY_SET_L,0);      // 操作モード：VFD表示 -> VFD設定
+  dispModeData = mode.modeSet(kEY_SET_L,0);      // 操作モード：VFD表示 -> VFD設定
   EXPECT_EQ(mode.getCtrlMode(), ctrlMode_VfdCtrl);
+  EXPECT_EQ(dispModeData.dispModeVfd, VFD_DISP_CLOCK_ADJ);  // VFD表示モード：時計調整
 
-  mode.modeSet(kEY_SET_L,0);      // 操作モード：VFD設定 -> VFD表示
+  dispModeData = mode.modeSet(kEY_SET_L,0);      // 操作モード：VFD設定 -> VFD表示
   EXPECT_EQ(mode.getCtrlMode(), ctrlMode_VfdDisp);
+  EXPECT_EQ(dispModeData.dispModeVfd, VFD_DISP_DEFAULT);    // VFD表示モード：標準表示
 
 }
 
@@ -235,7 +246,8 @@ TEST(ModeCtrl_sw2sw3, dispModeSetVFDCtrl){
   EXPECT_EQ(mode.getDispModeVfd(), VFD_DISP_FADETIME_ADJ);    // クロスフェード時間設定
 
   mode.modeSet(KEY_UP_S,0);                                   // 表示モードプラス確認
-  EXPECT_EQ(mode.getDispModeVfd(), VFD_DISP_BRIGHTNESS_ADJ);  // VFD輝度調整
+//  EXPECT_EQ(mode.getDispModeVfd(), VFD_DISP_BRIGHTNESS_ADJ);  // VFD輝度調整
+  EXPECT_EQ(mode.getDispModeVfd(), VFD_DISP_CLOCK_ADJ);       // 時計調整
 
 }
 


### PR DESCRIPTION
上記テスト追加。
close #46 